### PR TITLE
Update SaaS toolkit guide date to 2026-07-27

### DIFF
--- a/bitroot-v3/src/content/data.ts
+++ b/bitroot-v3/src/content/data.ts
@@ -130,7 +130,7 @@ export const guides: Item[] = [
     summary:
       "A category-by-category toolkit for taking a SaaS from idea to paying customers on near-zero fixed spend — what to prioritize in hosting, database, auth, payments, analytics, email, and more, and the order to add them in.",
     tags: ["SaaS", "Bootstrapping", "Tools", "Free tier"],
-    updatedAt: "2026-07-21",
+    updatedAt: "2026-07-27",
     href: "/guides/launch-a-saas-on-almost-0-per-month",
     difficulty: "starter",
   },


### PR DESCRIPTION
## Summary
- Updates `updatedAt` for the "Launching a SaaS on (Almost) $0/Month" guide from `2026-07-21` to `2026-07-27`

## Test plan
- [x] `npm run build` — production static export succeeds


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7F6gEqcAeKcc1QAD4asRJ)_